### PR TITLE
test: establish deterministic verification baseline

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -130,11 +130,11 @@
 * **LLM Instructions**: Act as a Python Packaging Expert. Generate a `pyproject.toml` file mapping to the existing `src/` layout. Ensure script entry points for the CLI and GUI are defined. Provide instructions on removing the `sys.path` hacks.
 
 ### [Design] Unit Tests for Core LP Logic and Data Loading
-* **Status**: Not Started
+* **Status**: Done (baseline) - `tests/test_engine_constraints.py` and `tests/test_utils.py`, see `plans/001-establish-verification-baseline.md`
 * **Target Files**: `tests/` (new), `src/nba_optimizer/engine.py`, `src/nba_optimizer/utils.py`
 * **Context**: The project currently relies entirely on manual verification. We need to introduce automated unit tests to catch regressions, starting specifically with the mathematical LP constraint logic and the CSV parsing/merging.
 * **Acceptance Criteria**:
-  * [ ] Propose a testing strategy using `pytest` that feeds dummy/mock data into `generate_single_lineup` to ensure salary caps and positional constraints are respected.
+  * [x] Propose a testing strategy using `pytest` that feeds dummy/mock data into `generate_single_lineup` to ensure salary caps and positional constraints are respected.
 * **LLM Instructions**: Act as a Senior QA Engineer. Draft a strategy for setting up a `pytest` suite for the `nba_optimizer`. Do not test the GUI or the orchestrator yet; focus solely on writing deterministic tests for the `PuLP` constraints in `engine.py` and the data loading in `utils.py`. Propose 3 specific test cases.
 
 ### [Research] Reduce Multiprocessing Serialization Overhead

--- a/README.md
+++ b/README.md
@@ -102,3 +102,23 @@ The project uses environment variables for path configuration to avoid exposing 
 - `NBA_OUTPUT_DIR`: Directory where the final upload-ready files are saved.
 
 Core roster constants (salary cap, roster size, etc.) are managed in `config.py`.
+
+## Testing
+
+A small, deterministic test suite covers shared CSV-parsing helpers and the
+core LP constraints used by the engine (roster size, salary band, positional
+eligibility, and minimum games). It is a safety rail for refactors, not a
+substitute for manual verification against real DraftKings exports.
+
+Install the dev dependencies and run the suite:
+
+```bash
+pip install -e .[dev]
+python -m pytest -q
+```
+
+Run a focused subset:
+
+```bash
+python -m pytest tests/test_engine_constraints.py tests/test_utils.py -q
+```

--- a/docs/codebase/CONCERNS.md
+++ b/docs/codebase/CONCERNS.md
@@ -6,7 +6,7 @@
 
 | Severity | Concern | Evidence | Impact | Suggested action |
 |----------|---------|----------|--------|------------------|
-| High | No automated tests | No test files in repo; test files were deleted | Regressions go undetected; manual verification only | Add unit tests for core LP logic and data loading |
+| Medium | Automated tests cover only a small baseline | `tests/test_utils.py`, `tests/test_engine_constraints.py` cover shared parsing helpers and core `generate_single_lineup` constraints; `ranker.py`, `exporter.py`, `exposure_report.py`, and `late_swapper.py` remain untested | Regressions in ranking, export, and late-swap logic go undetected; manual verification still required for most of the pipeline | Extend the suite with focused characterization tests as those modules are touched (see `docs/codebase/TESTING.md`) |
 | High | Duplicate `load_data()` implementations | `engine.py:load_data()` vs `late_swapper.py:load_data()` have different CSV parsing logic | Bugs fixed in one may not be fixed in the other; subtle data inconsistencies | Consolidate into `utils.py` or a shared data loader |
 | Medium | Stale file pickup after failed runs | All modules use "latest file by timestamp" heuristic | A failed engine run leaves a partial lineup pool that the ranker may pick up | Add validation (e.g., row count check) or a run-ID linking mechanism |
 | Medium | `engine.py` is 400+ lines mixing data loading, LP construction, slotting, and orchestration | `engine.py` (13.9KB, highest churn at 14 commits) | Hard to modify one concern without risking another | Extract `load_data`, `slot_lineup_by_time`, and `generate_single_lineup` into focused modules |

--- a/docs/codebase/STACK.md
+++ b/docs/codebase/STACK.md
@@ -27,13 +27,17 @@
 
 | Tool | Purpose | Evidence |
 |------|---------|----------|
-| None configured | No linter, formatter, or test runner configured | Scan output: "No linting or formatting config files found" |
+| pytest | Dev-only test runner for `tests/` (deterministic baseline suite) | `pyproject.toml` `[project.optional-dependencies].dev` |
+| None configured | No linter or formatter configured | Scan output: "No linting or formatting config files found" |
 
 ### 4) Key Commands
 
 ```bash
 # Install
 pip install -e .
+
+# Install with dev/test dependencies
+pip install -e .[dev]
 
 # Run full pipeline (CLI)
 python scripts/run_optimizer.py -n 2500 -r 0.25
@@ -44,7 +48,10 @@ python scripts/run_optimizer_gui.py
 # Run late swap
 python scripts/run_optimizer.py --late_swap
 
-# No build, test, or lint commands configured
+# Run the test suite
+python -m pytest -q
+
+# No build or lint commands configured
 ```
 
 ### 5) Environment and Config

--- a/docs/codebase/TESTING.md
+++ b/docs/codebase/TESTING.md
@@ -4,39 +4,50 @@
 
 ### 1) Test Stack and Commands
 
-- Primary test framework: None configured
-- Assertion/mocking tools: None configured
-- Commands: N/A
+- Primary test framework: `pytest` (dev-only, via `pip install -e .[dev]`)
+- Assertion/mocking tools: plain `pytest` asserts; no mocking framework
+- Commands:
 
 ```bash
-# No test commands available
+# Install core + dev dependencies
+pip install -e .[dev]
+
+# Run the full suite
+python -m pytest -q
+
+# Run a focused subset (utility helpers + engine constraints)
+python -m pytest tests/test_engine_constraints.py tests/test_utils.py -q
 ```
 
 ### 2) Test Layout
 
-- Test file placement pattern: Previously had a `tests/` directory (evidenced by git churn: `tests/test_late_swapper.py`, `tests/test_data/DKEntries.csv`). These files were removed in commit `f0498b1` ("chore: remove deprecated test data and scripts").
-- Current state: No test files exist in the repository.
+- Test file placement pattern: `tests/` at the repo root, mirroring the `src/nba_optimizer/` module names (`tests/test_utils.py`, `tests/test_engine_constraints.py`). Small CSV fixtures live in `tests/fixtures/`.
+- History note: an earlier `tests/` directory (`tests/test_late_swapper.py`, `tests/test_data/DKEntries.csv`) was removed in commit `f0498b1` ("chore: remove deprecated test data and scripts"). The current suite is a fresh, intentionally minimal baseline rather than a restoration of that code.
+- Current state: `tests/test_utils.py` and `tests/test_engine_constraints.py` exist, covering shared parsing helpers and core LP constraints.
 
 ### 3) Test Scope Matrix
 
 | Scope | Covered? | Typical target | Notes |
 |-------|----------|----------------|-------|
-| Unit | No | N/A | No test files exist |
-| Integration | No | N/A | No test files exist |
-| E2E | No (manual) | Full pipeline | Verification is done by running the pipeline and inspecting CSV output |
+| Unit | Yes (partial) | `nba_optimizer.utils` parsing helpers (`extract_player_id`, `parse_game_time`, `read_ragged_csv`) | Deterministic, pure-function tests |
+| Unit/Integration | Yes (partial) | `nba_optimizer.engine.generate_single_lineup` | Exercises the LP solve directly with `randomness=0.0` against a tiny synthetic player pool; asserts roster size, salary band, positional eligibility, and min-games constraints |
+| Integration | No | Full `engine` -> `ranker` -> `exporter` -> `exposure_report` pipeline | Not covered; would require real DraftKings CSV fixtures |
+| E2E | No (manual) | Full pipeline | Verification is done by running the pipeline with real CSV inputs and inspecting output |
 
 ### 4) Mocking and Isolation Strategy
 
-- No mocking strategy exists. The project has no test infrastructure.
+- No mocking. Tests call the real `generate_single_lineup()` worker and the real `nba_optimizer.utils` helpers against small, explicit, hand-built data (inline DataFrames or a tiny CSV fixture in `tests/fixtures/`).
+- Tests are intentionally transparent and domain-relevant per project guidance: no opaque snapshot tests or broad mock-heavy scaffolding.
 
 ### 5) Coverage and Quality Signals
 
-- Coverage tool + threshold: None
-- Current reported coverage: None
-- Known gaps: All code is untested. The highest-churn files (`engine.py` at 14 changes, `late_swapper.py` at 8) have no automated tests.
+- Coverage tool + threshold: None configured
+- Current reported coverage: Not measured
+- Known gaps: `ranker.py`, `exporter.py`, `exposure_report.py`, and `late_swapper.py` have no automated tests. The new suite is a baseline for `engine.py`'s core constraint logic and shared `utils.py` helpers only; manual CSV-based verification is still required for real-slate behavior and the rest of the pipeline.
 
 ### 6) Evidence
 
+- `tests/test_utils.py`, `tests/test_engine_constraints.py`, `tests/fixtures/ragged_sample.csv`
+- `pyproject.toml`: `[project.optional-dependencies].dev` adds `pytest`
 - Git churn output (scan): `tests/test_late_swapper.py` appears in high-churn list but no longer exists
 - Commit `f0498b1`: "chore: remove deprecated test data and scripts"
-- `README.md`: No mention of testing or test commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@ dependencies = [
     "wxPython==4.2.5",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+]
+
 [project.scripts]
 nba-dfs-optimizer = "nba_optimizer.cli:main"
 nba-dfs-optimizer-gui = "nba_optimizer.gui:main"

--- a/tests/fixtures/ragged_sample.csv
+++ b/tests/fixtures/ragged_sample.csv
@@ -1,0 +1,3 @@
+Entry ID,Contest Name,Contest ID,Entry Fee
+111,Main Slate,222,3
+333,Main Slate,222,3,extra_value_a,extra_value_b

--- a/tests/test_engine_constraints.py
+++ b/tests/test_engine_constraints.py
@@ -56,11 +56,11 @@ def _is_slot_eligible(pos_str: str, slot: str) -> bool:
 
 def test_lineup_size_and_salary_bounds():
     """A solved lineup has exactly roster_size players within the salary band."""
-    df = _build_pool()
+    df_pool = _build_pool()
     cfg = Config()
 
     lineup_names, selected_indices = generate_single_lineup(
-        df,
+        df_pool,
         randomness=0.0,
         min_salary=cfg.min_salary,
         salary_cap=cfg.salary_cap,
@@ -72,18 +72,18 @@ def test_lineup_size_and_salary_bounds():
     assert len(lineup_names) == cfg.roster_size
     assert len(selected_indices) == cfg.roster_size
 
-    total_salary = df.loc[list(selected_indices), "Salary"].sum()
+    total_salary = df_pool.loc[list(selected_indices), "Salary"].sum()
     assert cfg.min_salary <= total_salary <= cfg.salary_cap
 
 
 def test_lineup_respects_position_eligibility_and_min_games():
     """Every selected player can fill at least one DK slot, and the
     lineup spans at least min_games distinct games."""
-    df = _build_pool()
+    df_pool = _build_pool()
     cfg = Config()
 
     lineup_names, selected_indices = generate_single_lineup(
-        df,
+        df_pool,
         randomness=0.0,
         min_salary=cfg.min_salary,
         salary_cap=cfg.salary_cap,
@@ -93,11 +93,11 @@ def test_lineup_respects_position_eligibility_and_min_games():
 
     assert lineup_names is not None, "expected a feasible lineup for this pool"
 
-    selected = df.loc[list(selected_indices)]
+    df_selected = df_pool.loc[list(selected_indices)]
 
     # Every selected player is slot-eligible for at least one of the 8 slots.
-    for pos_str in selected["Roster Position"]:
+    for pos_str in df_selected["Roster Position"]:
         assert any(_is_slot_eligible(pos_str, slot) for slot in ROSTER_SLOTS)
 
     # The lineup spans at least min_games distinct games.
-    assert selected["Game"].nunique() >= cfg.min_games
+    assert df_selected["Game"].nunique() >= cfg.min_games

--- a/tests/test_engine_constraints.py
+++ b/tests/test_engine_constraints.py
@@ -1,0 +1,103 @@
+"""Deterministic tests for the core LP constraints in
+nba_optimizer.engine.generate_single_lineup.
+
+These exercise the worker function directly against a tiny synthetic player
+pool (randomness=0.0) so the solve is reproducible. The pool is constructed
+so that exactly one combination of 8 players satisfies the salary, roster
+size, positional, and min-games constraints simultaneously -- the two cheap
+bench players exist only to give the solver alternatives that it must reject
+because including either of them breaks the salary-floor or roster-size
+constraint.
+"""
+
+import pandas as pd
+
+from nba_optimizer.config import ROSTER_SLOTS, Config
+from nba_optimizer.engine import generate_single_lineup
+
+
+def _build_pool() -> pd.DataFrame:
+    """Build a small synthetic player pool spanning two games.
+
+    The first 8 rows are priced at 6200 (total 49600, inside the default
+    49500-50000 salary band) and cover all 8 roster slots exactly once.
+    The last 2 rows are cheap bench players that the solver must leave on
+    the bench: swapping either of them in would require dropping one of
+    the 8 slot-covering players, which breaks positional eligibility.
+    """
+    data = [
+        # Name + ID,   Salary, Roster Position, Projection, Game
+        ("PG1 (1)", 6200, "PG", 40, "GAMEA"),
+        ("SG1 (2)", 6200, "SG", 40, "GAMEA"),
+        ("SF1 (3)", 6200, "SF", 40, "GAMEA"),
+        ("PF1 (4)", 6200, "PF", 40, "GAMEA"),
+        ("C1 (5)", 6200, "C", 40, "GAMEA"),
+        ("G1 (6)", 6200, "PG/SG", 38, "GAMEB"),
+        ("F1 (7)", 6200, "SF/PF", 38, "GAMEB"),
+        ("U1 (8)", 6200, "C", 38, "GAMEB"),
+        ("PG2 (9)", 3000, "PG", 10, "GAMEB"),
+        ("SG2 (10)", 3000, "SG", 10, "GAMEB"),
+    ]
+    return pd.DataFrame(
+        data, columns=["Name + ID", "Salary", "Roster Position", "Projection", "Game"]
+    )
+
+
+def _is_slot_eligible(pos_str: str, slot: str) -> bool:
+    """Mirror the slot-eligibility rules from generate_single_lineup."""
+    if slot == "UTIL":
+        return True
+    if slot == "G":
+        return "PG" in pos_str or "SG" in pos_str
+    if slot == "F":
+        return "SF" in pos_str or "PF" in pos_str
+    return slot in pos_str
+
+
+def test_lineup_size_and_salary_bounds():
+    """A solved lineup has exactly roster_size players within the salary band."""
+    df = _build_pool()
+    cfg = Config()
+
+    lineup_names, selected_indices = generate_single_lineup(
+        df,
+        randomness=0.0,
+        min_salary=cfg.min_salary,
+        salary_cap=cfg.salary_cap,
+        roster_size=cfg.roster_size,
+        min_games=cfg.min_games,
+    )
+
+    assert lineup_names is not None, "expected a feasible lineup for this pool"
+    assert len(lineup_names) == cfg.roster_size
+    assert len(selected_indices) == cfg.roster_size
+
+    total_salary = df.loc[list(selected_indices), "Salary"].sum()
+    assert cfg.min_salary <= total_salary <= cfg.salary_cap
+
+
+def test_lineup_respects_position_eligibility_and_min_games():
+    """Every selected player can fill at least one DK slot, and the
+    lineup spans at least min_games distinct games."""
+    df = _build_pool()
+    cfg = Config()
+
+    lineup_names, selected_indices = generate_single_lineup(
+        df,
+        randomness=0.0,
+        min_salary=cfg.min_salary,
+        salary_cap=cfg.salary_cap,
+        roster_size=cfg.roster_size,
+        min_games=cfg.min_games,
+    )
+
+    assert lineup_names is not None, "expected a feasible lineup for this pool"
+
+    selected = df.loc[list(selected_indices)]
+
+    # Every selected player is slot-eligible for at least one of the 8 slots.
+    for pos_str in selected["Roster Position"]:
+        assert any(_is_slot_eligible(pos_str, slot) for slot in ROSTER_SLOTS)
+
+    # The lineup spans at least min_games distinct games.
+    assert selected["Game"].nunique() >= cfg.min_games

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,68 @@
+"""Deterministic tests for shared parsing helpers in nba_optimizer.utils.
+
+These cover the small, pure-function behaviors that the rest of the
+pipeline (engine, ranker, exporter, late_swapper) all rely on for parsing
+DraftKings CSV exports.
+"""
+
+import os
+from datetime import datetime
+
+import pandas as pd
+
+from nba_optimizer.utils import extract_player_id, parse_game_time, read_ragged_csv
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+def test_extract_player_id_from_name_and_id_string():
+    """A normal 'Name (ID)' string yields the numeric ID."""
+    assert extract_player_id("LeBron James (12345)") == "12345"
+
+
+def test_extract_player_id_handles_missing_value():
+    """A null/missing player value returns None instead of raising."""
+    assert extract_player_id(pd.NA) is None
+    assert extract_player_id(None) is None
+
+
+def test_extract_player_id_returns_none_without_id():
+    """A string with no parenthesized ID returns None."""
+    assert extract_player_id("LeBron James") is None
+
+
+def test_parse_game_time_valid_dk_game_info():
+    """A valid DK 'Game Info' string parses to the expected datetime."""
+    result = parse_game_time("MIA@PHI 02/25/2026 07:00PM ET")
+    assert result == datetime(2026, 2, 25, 19, 0)
+
+
+def test_parse_game_time_invalid_falls_back_to_max():
+    """An unparseable game-info string falls back to datetime.max."""
+    assert parse_game_time("not a real game info string") == datetime.max
+
+
+def test_read_ragged_csv_preserves_valid_columns_and_pads_ragged_rows():
+    """read_ragged_csv keeps the real header columns and pads short/long rows."""
+    csv_path = os.path.join(FIXTURES_DIR, "ragged_sample.csv")
+
+    df, valid_cols = read_ragged_csv(csv_path, max_columns=6)
+
+    # The original 4 header columns are reported back unchanged.
+    assert valid_cols == ["Entry ID", "Contest Name", "Contest ID", "Entry Fee"]
+
+    # The padded frame has 2 extra dummy columns appended.
+    assert df.columns.tolist() == valid_cols + ["extra_0", "extra_1"]
+
+    # The first row had no extra values, so the padding columns are NaN.
+    assert pd.isna(df.loc[0, "extra_0"])
+    assert pd.isna(df.loc[0, "extra_1"])
+
+    # The second (ragged) row's extra values land in the padding columns.
+    assert df.loc[1, "extra_0"] == "extra_value_a"
+    assert df.loc[1, "extra_1"] == "extra_value_b"
+
+    # Valid columns retain their original data for both rows. Entry ID is
+    # read as a string (object dtype) to avoid losing precision on large IDs.
+    assert df.loc[0, "Entry ID"] == "111"
+    assert df.loc[1, "Entry ID"] == "333"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,23 +46,23 @@ def test_read_ragged_csv_preserves_valid_columns_and_pads_ragged_rows():
     """read_ragged_csv keeps the real header columns and pads short/long rows."""
     csv_path = os.path.join(FIXTURES_DIR, "ragged_sample.csv")
 
-    df, valid_cols = read_ragged_csv(csv_path, max_columns=6)
+    df_ragged, valid_cols = read_ragged_csv(csv_path, max_columns=6)
 
     # The original 4 header columns are reported back unchanged.
     assert valid_cols == ["Entry ID", "Contest Name", "Contest ID", "Entry Fee"]
 
     # The padded frame has 2 extra dummy columns appended.
-    assert df.columns.tolist() == valid_cols + ["extra_0", "extra_1"]
+    assert df_ragged.columns.tolist() == valid_cols + ["extra_0", "extra_1"]
 
     # The first row had no extra values, so the padding columns are NaN.
-    assert pd.isna(df.loc[0, "extra_0"])
-    assert pd.isna(df.loc[0, "extra_1"])
+    assert pd.isna(df_ragged.loc[0, "extra_0"])
+    assert pd.isna(df_ragged.loc[0, "extra_1"])
 
     # The second (ragged) row's extra values land in the padding columns.
-    assert df.loc[1, "extra_0"] == "extra_value_a"
-    assert df.loc[1, "extra_1"] == "extra_value_b"
+    assert df_ragged.loc[1, "extra_0"] == "extra_value_a"
+    assert df_ragged.loc[1, "extra_1"] == "extra_value_b"
 
     # Valid columns retain their original data for both rows. Entry ID is
     # read as a string (object dtype) to avoid losing precision on large IDs.
-    assert df.loc[0, "Entry ID"] == "111"
-    assert df.loc[1, "Entry ID"] == "333"
+    assert df_ragged.loc[0, "Entry ID"] == "111"
+    assert df_ragged.loc[1, "Entry ID"] == "333"


### PR DESCRIPTION
## Summary
- Adds a dev-only `pytest` dependency group (`pip install -e .[dev]`)
- Adds `tests/test_utils.py` covering `extract_player_id`, `parse_game_time`, and `read_ragged_csv`
- Adds `tests/test_engine_constraints.py` covering `generate_single_lineup` (roster size, salary band, positional eligibility, min-games) with a deterministic synthetic player pool (`randomness=0.0`)
- Documents the new baseline in `README.md`, `docs/codebase/TESTING.md`, `docs/codebase/STACK.md`, and `docs/codebase/CONCERNS.md`, and marks the corresponding `BACKLOG.md` item done

Implements plan `plans/001-establish-verification-baseline.md` (closes #40).

## Test plan
- [x] `pip install -e .[dev]` exits 0
- [x] `python -c "from nba_optimizer import engine, ranker, exporter, late_swapper, utils"` exits 0
- [x] `python -m pytest -q` → 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)