### PR TITLE
chore: add SessionStart hook to bootstrap deps in cloud sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# SessionStart hook: bootstraps Python deps for Claude Code on the web sessions.
+# Skipped entirely on local developer machines.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+REPO_DIR="${CLAUDE_PROJECT_DIR:-$(git -C "$(dirname "$0")" rev-parse --show-toplevel)}"
+VENV_DIR="$REPO_DIR/.venv"
+
+# Create the venv once; re-use it on resume.
+if [ ! -d "$VENV_DIR" ]; then
+  python3 -m venv "$VENV_DIR"
+fi
+
+# Install / upgrade the package plus dev extras (pytest).
+# Uses pip's own caching — already-satisfied deps are fast on resume.
+"$VENV_DIR/bin/pip" install --quiet --upgrade pip
+"$VENV_DIR/bin/pip" install --quiet -e "$REPO_DIR[dev]"
+
+# Export the venv bin dir onto PATH for every startup and resume.
+echo "export PATH=\"$VENV_DIR/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -21,4 +21,7 @@ fi
 "$VENV_DIR/bin/pip" install --quiet -e "$REPO_DIR[dev]"
 
 # Export the venv bin dir onto PATH for every startup and resume.
-echo "export PATH=\"$VENV_DIR/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+# Guard against $CLAUDE_ENV_FILE being unset or empty (set -u would otherwise crash).
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "export PATH=\"$VENV_DIR/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "worktree": {
     "baseRef": "head"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Environment / Workspace-specific Files
 venv/
+.venv/
 .env
 .vscode
 


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/session-start.sh` — a SessionStart hook that runs only in remote Claude Code on the web sessions (`CLAUDE_CODE_REMOTE=true`). On every `startup` or `resume` event it creates a repo-local `.venv` (if absent), installs the package and dev extras (`pip install -e .[dev]`), and exports the venv bin dir onto PATH via `$CLAUDE_ENV_FILE` so `pytest` and the optimizer CLI are immediately available.
- Registers the hook in `.claude/settings.json` under `SessionStart` with `"matcher": "startup|resume"`, merging with the existing `worktree` config.
- Adds `.venv/` to `.gitignore` so the bootstrapped environment is never committed.

## Validation results

1. ✅ **Session hook execution** — ran with `CLAUDE_CODE_REMOTE=true`; exited 0. Cold install: ~19 s. Subsequent resume (deps already cached by pip): ~3 s.
2. ✅ **Linter** — no linter is configured in this project (`pyproject.toml` defines no ruff/flake8/pylint/mypy tooling); skipped rather than inventing one.
3. ✅ **Tests** — `python -m pytest tests/test_utils.py -q` → **16 passed in 0.34 s** against the venv installed by the hook.

## Hook execution mode: Synchronous

The hook runs **synchronously** — the session starts only after the hook exits.

- **Pro:** Guarantees dependencies are present before your session starts; no race where Claude tries to run tests or the optimizer before the venv exists.
- **Con:** Each session start waits ~19 s on a cold container (warm resume is ~3 s). Let me know if you'd prefer async mode for faster startup — I can switch it, but it introduces the race condition described above.

## Environment / web-UI notes

- **Network access:** The default "Trusted" allowlist in Claude Code on the web already covers PyPI, so no custom network policy is needed.
- **Environment variables / secrets:** None required to run the test suite. The suite uses synthetic fixtures and stubs — no external integrations are called. The optimizer itself uses `.env` for optional config, but that file is gitignored and not needed for tests.
- **How it works for contributors:** Once this branch is merged into `main`, any cloud session cloned from this repo will automatically bootstrap its environment via the hook — no manual `pip install` step needed. The hook is a no-op locally (guarded by `CLAUDE_CODE_REMOTE=true`), so it's safe for all developers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CpGsohD2mbS5BBEEXfTTg

---
_Generated by [Claude Code](https://claude.ai/code/session_019CpGsohD2mbS5BBEEXfTTg)_