### PR TITLE
docs: refresh AGENTS/CLAUDE/README for loader consolidation + cloud SessionStart hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,12 +18,13 @@ This project runs on Windows with PowerShell. Use PowerShell-compatible syntax f
 ## Architecture
 
 This repo is a sequential file-based pipeline:
-1. `scripts/run_optimizer.py` orchestrates the flow.
+1. `scripts/run_optimizer.py` → `cli.py` → `src/nba_optimizer/orchestrator.py` drives the flow, passing each stage's output file path directly to the next stage (explicit artifact handoff).
 2. `src/nba_optimizer/engine.py` generates lineup pools.
 3. `src/nba_optimizer/ranker.py` ranks lineups.
 4. `src/nba_optimizer/exporter.py` writes DraftKings upload CSVs.
 5. `src/nba_optimizer/exposure_report.py` prints exposure analysis.
 6. `src/nba_optimizer/late_swapper.py` is the separate late-swap path.
+7. `src/nba_optimizer/utils.py` holds the shared player-pool loader (`parse_dk_entries`, `merge_player_pool`) plus file/parsing helpers used across stages.
 
 Keep responsibilities in those modules. Do not move export, ranking, or report logic into the optimizer engine.
 
@@ -59,14 +60,19 @@ pip install -e .[gui]
 
 ## Repo-Specific Pitfalls
 
-- Stages communicate through timestamped CSV files. Be careful with any "latest file" logic because stale outputs from a previous failed run can be picked up.
-- Data loading is currently split across `engine.py` and `late_swapper.py`. If you change projection or DKEntries parsing, check both paths for parity.
-- `ranker.py` currently depends on `engine.load_data()`. Avoid creating more cross-module coupling unless you are intentionally refactoring shared data loading.
-- `engine.py` and `late_swapper.py` are the riskiest files to change because they are large, high-churn, and untested.
+- Stages communicate through timestamped CSV files. The orchestrator now passes each stage's output path explicitly to the next stage, so stale outputs cannot be silently picked up on the orchestrated path. Standalone module invocations (`python -m nba_optimizer.<module>`) still fall back to "latest file" lookup, so beware stale outputs from a failed run there.
+- Player-pool loading is consolidated in `utils.parse_dk_entries` and `utils.merge_player_pool`; engine, ranker, and late_swapper all share it (plan 004). Engine and ranker merge with `how="inner"`; late_swapper merges with `how="left"` and derives the canonical `Game` column via `derive_game_key`. If you change projection or DKEntries parsing, that single path covers every stage — but confirm both merge modes still behave.
+- `engine.py` and `late_swapper.py` are the riskiest files to change because they are large and high-churn (`late_swapper.py` now has targeted tests; engine's LP constraints are covered, but its data/slotting plumbing is not).
 
 ## Testing And Verification
 
-A small deterministic pytest baseline exists (`tests/test_utils.py`, `tests/test_engine_constraints.py`), covering shared parsing helpers and core `engine.generate_single_lineup` LP constraints. `ranker.py`, `exporter.py`, `exposure_report.py`, and `late_swapper.py` remain untested — prefer targeted manual verification with real CSV inputs and output inspection for those.
+A deterministic pytest baseline exists:
+- `tests/test_utils.py` — shared parsing/loader helpers (`parse_dk_entries`, `merge_player_pool`, etc.).
+- `tests/test_engine_constraints.py` — core `engine.generate_single_lineup` LP constraints (roster size, salary band, positional eligibility, `min_games`).
+- `tests/test_late_swap.py` — late-swap game-key resolution, lock detection, and enforced `min_games`.
+- `tests/test_pipeline_artifacts.py` — explicit artifact handoff between stages (ranker/exporter/exposure_report honor passed-in paths over "latest file").
+
+The core ranking/export/leverage logic in `ranker.py`, `exporter.py`, and `exposure_report.py` remains otherwise untested — prefer targeted manual verification with real CSV inputs and output inspection for those.
 
 Do not add generic or opaque tests just to increase coverage. New tests must be transparent, domain-relevant, and directly tied to real optimizer behavior. See `docs/codebase/TESTING.md` for details.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,9 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-All project conventions, architecture, build/run commands, pitfalls, and testing
-guidance live in the shared agent guide. Read it first:
-
 @AGENTS.md
 
-## Claude Code Specifics
-
-The notes below apply only to Claude Code and supplement (do not replace) `AGENTS.md`.
+## Claude Code
 
 ### Cloud sessions (Claude Code on the web)
 
-This repo ships a `SessionStart` hook at `.claude/hooks/session-start.sh`, wired up in
-`.claude/settings.json` under the `startup|resume` matcher. It bootstraps the Python
-environment so tests and linters work in remote sessions:
-
-- It runs **only** when `CLAUDE_CODE_REMOTE=true`; on a local developer machine it exits
-  immediately and changes nothing.
-- In a cloud session it creates `.venv/` (once, reused on resume), installs the package with
-  dev extras (`pip install -e .[dev]`), and prepends `.venv/bin` to `PATH` via
-  `$CLAUDE_ENV_FILE` so `python` and `pytest` resolve to the venv on every startup and resume.
-
-Because of this, in a cloud session you can run `python -m pytest -q` directly without a
-manual install step. If dependencies seem missing, confirm the hook ran (check for `.venv/`)
-rather than re-installing by hand. See https://code.claude.com/docs/en/claude-code-on-the-web
-for how remote environments, triggers, and SessionStart hooks work.
-
-> Note: `AGENTS.md` states the project targets Windows/PowerShell for local development.
-> Cloud sessions run on Linux, so the bootstrap hook and `.venv/bin` paths above are
-> POSIX-shell specific and apply to the remote environment only.
+- A `SessionStart` hook (`.claude/hooks/session-start.sh`, matcher `startup|resume`) runs only when `CLAUDE_CODE_REMOTE=true` and is a no-op locally.
+- In a cloud session it creates `.venv/`, runs `pip install -e .[dev]`, and prepends `.venv/bin` to `PATH`, so `python` and `pytest` are ready without a manual install.
+- Local development targets Windows/PowerShell (see `AGENTS.md`); the hook and `.venv/bin` paths are POSIX-only and apply to remote sessions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,33 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+All project conventions, architecture, build/run commands, pitfalls, and testing
+guidance live in the shared agent guide. Read it first:
+
 @AGENTS.md
+
+## Claude Code Specifics
+
+The notes below apply only to Claude Code and supplement (do not replace) `AGENTS.md`.
+
+### Cloud sessions (Claude Code on the web)
+
+This repo ships a `SessionStart` hook at `.claude/hooks/session-start.sh`, wired up in
+`.claude/settings.json` for the `startup` and `resume` matchers. It bootstraps the Python
+environment so tests and linters work in remote sessions:
+
+- It runs **only** when `CLAUDE_CODE_REMOTE=true`; on a local developer machine it exits
+  immediately and changes nothing.
+- In a cloud session it creates `.venv/` (once, reused on resume), installs the package with
+  dev extras (`pip install -e .[dev]`), and prepends `.venv/bin` to `PATH` via
+  `$CLAUDE_ENV_FILE` so `python` and `pytest` resolve to the venv on every startup and resume.
+
+Because of this, in a cloud session you can run `python -m pytest -q` directly without a
+manual install step. If dependencies seem missing, confirm the hook ran (check for `.venv/`)
+rather than re-installing by hand. See https://code.claude.com/docs/en/claude-code-on-the-web
+for how remote environments, triggers, and SessionStart hooks work.
+
+> Note: `AGENTS.md` states the project targets Windows/PowerShell for local development.
+> Cloud sessions run on Linux, so the bootstrap hook and `.venv/bin` paths above are
+> POSIX-shell specific and apply to the remote environment only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The notes below apply only to Claude Code and supplement (do not replace) `AGENT
 ### Cloud sessions (Claude Code on the web)
 
 This repo ships a `SessionStart` hook at `.claude/hooks/session-start.sh`, wired up in
-`.claude/settings.json` for the `startup` and `resume` matchers. It bootstraps the Python
+`.claude/settings.json` under the `startup|resume` matcher. It bootstraps the Python
 environment so tests and linters work in remote sessions:
 
 - It runs **only** when `CLAUDE_CODE_REMOTE=true`; on a local developer machine it exits

--- a/README.md
+++ b/README.md
@@ -128,3 +128,18 @@ Run a focused subset:
 ```bash
 python -m pytest tests/test_engine_constraints.py tests/test_utils.py -q
 ```
+
+The suite also covers late-swap lock handling and enforced minimum games
+(`tests/test_late_swap.py`) and explicit artifact handoff between pipeline stages
+(`tests/test_pipeline_artifacts.py`).
+
+## Development Notes
+
+- **Shared data loading.** DKEntries and projection parsing is consolidated in
+  `src/nba_optimizer/utils.py` (`parse_dk_entries`, `merge_player_pool`) and shared by the
+  engine, ranker, and late swapper. The engine and ranker merge the player pool with an inner
+  join; the late swapper uses a left join and derives the matchup `Game` column itself.
+- **Claude Code on the web.** A `SessionStart` hook (`.claude/hooks/session-start.sh`, wired in
+  `.claude/settings.json`) bootstraps a `.venv` and installs `pip install -e .[dev]` for remote
+  cloud sessions. It runs only when `CLAUDE_CODE_REMOTE=true` and is a no-op on local machines,
+  so local development is unaffected.


### PR DESCRIPTION
## Summary

Refreshes the project docs to reflect codebase changes since they were last touched, and adds Claude-specific guidance.

### AGENTS.md
- **Architecture:** note that `scripts/run_optimizer.py → cli.py → orchestrator.py` drives the flow with explicit per-stage artifact handoff, and add `utils.py` as the shared player-pool loader.
- **Pitfalls:** replace stale items — data loading is no longer split across `engine.py`/`late_swapper.py`, and `ranker.py` no longer depends on `engine.load_data()`. Both now share `utils.parse_dk_entries` / `merge_player_pool` (plan 004), with engine/ranker using an inner merge and late_swapper a left merge + `derive_game_key`. Clarify the stale-file warning now only applies to standalone module invocations.
- **Testing:** update the baseline list to include `test_late_swap.py` and `test_pipeline_artifacts.py`.

### CLAUDE.md
- Add the standard Claude Code header, keep the `@AGENTS.md` reference, and add a **Cloud sessions** section documenting the `SessionStart` hook (`.claude/hooks/session-start.sh`) — `CLAUDE_CODE_REMOTE`-gated venv bootstrap that's a no-op locally.

### README.md
- Mention the new late-swap and pipeline-artifact tests, and add a **Development Notes** section covering the shared `utils.py` loader and the cloud SessionStart hook.

## Verification
- `python -c "from nba_optimizer import engine, ranker, exporter"` → OK
- `python -m pytest -q` → 37 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011L1dLFg15yqK9LHmvbx4SP

---
_Generated by [Claude Code](https://claude.ai/code/session_011L1dLFg15yqK9LHmvbx4SP)_